### PR TITLE
Expose certain parameters to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ run_spike_sorting_ibl(bin_file, delete=DELETE, scratch_dir=scratch_dir,
 ### System Requirements
 
 The code makes extensive use of the GPU via the CUDA framework. A high-end NVIDIA GPU with at least 8GB of memory is required.
-The solution has been deployed and tested on Cuda 12+.
+The solution has been deployed and tested on Cuda 12+ and Python 3.11.
+In June 2024, pyfftw was still not compatible with Python 3.12.
 
 ### Python environment
 
@@ -61,8 +62,16 @@ Navigate to the desired location for the repository and clone it
     git clone https://github.com/int-brain-lab/ibl-sorter.git
     cd ibl-sorter
 
+Installation for cuda 11.8
+
+    pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+    pip install cupy-cuda11x
+    pip install -e .
+
+Installation for cuda 12.1
+
+    pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu12.1
     pip install cupy-cuda12x
-    pip3 install torch torchvision torchaudio
     pip install -e .
 
 ### Making sure the installation is successful and CUDA is available
@@ -72,4 +81,10 @@ Here we make sure that both `cupy` and `torch` are installed and that the CUDA f
 ```python
 from iblsorter.utils import cuda_installation_test
 cuda_installation_test()
+```
+
+Then we can run the integration test
+    
+```shell
+python ./examples/integration_100s.py /mnt/s1/spikesorting/integration_tests/stand-alone/
 ```

--- a/examples/integration_100s.py
+++ b/examples/integration_100s.py
@@ -1,13 +1,19 @@
 import shutil
 from pathlib import Path
+import sys
 
 import iblsorter
 from iblsorter.ibl import run_spike_sorting_ibl, ibl_pykilosort_params, download_test_data
 from viz import reports
 
+location = sys.argv[1]
+
 # TODO automate download of the test data from s3, should contain imec_385_100s.ap.bin and imec_385_100s.ap.meta
-INTEGRATION_DATA_PATH = Path("/datadisk/Data/neuropixel/integration_tests") # parede
-# INTEGRATION_DATA_PATH = Path("/mnt/s0/spikesorting/integration_tests/stand-alone/") # steinmetzlab
+if location == "server":
+    INTEGRATION_DATA_PATH = Path("/mnt/s0/spikesorting/integration_tests/stand-alone/") # steinmetzlab
+else:    
+    INTEGRATION_DATA_PATH = Path("/datadisk/Data/neuropixel/integration_tests") # parede
+    
 SCRATCH_DIR = Path.home().joinpath("scratch", 'iblsort')
 
 DELETE = True  # delete the intermediate run products, if False they'll be copied over

--- a/examples/integration_100s.py
+++ b/examples/integration_100s.py
@@ -1,3 +1,4 @@
+import argparse
 import shutil
 from pathlib import Path
 import sys
@@ -6,14 +7,16 @@ import iblsorter
 from iblsorter.ibl import run_spike_sorting_ibl, ibl_pykilosort_params, download_test_data
 from viz import reports
 
-location = sys.argv[1]
-
+parser = argparse.ArgumentParser(description='Run the 100s integration test with iblsort')
+parser.add_argument('location', help='server or local', default='server')
+args = parser.parse_args()
 # TODO automate download of the test data from s3, should contain imec_385_100s.ap.bin and imec_385_100s.ap.meta
-if location == "server":
-    INTEGRATION_DATA_PATH = Path("/mnt/s0/spikesorting/integration_tests/stand-alone/") # steinmetzlab
+
+if args.location == "server":
+    INTEGRATION_DATA_PATH = Path("/mnt/s0/spikesorting/integration_tests/stand-alone/")
 else:    
-    INTEGRATION_DATA_PATH = Path("/datadisk/Data/neuropixel/integration_tests") # parede
-    
+    INTEGRATION_DATA_PATH = Path(args.location)
+print(f"Using integration data path: {INTEGRATION_DATA_PATH}")
 SCRATCH_DIR = Path.home().joinpath("scratch", 'iblsort')
 
 DELETE = True  # delete the intermediate run products, if False they'll be copied over

--- a/iblsorter/datashift2.py
+++ b/iblsorter/datashift2.py
@@ -442,34 +442,35 @@ def dartsort_detector(ctx, probe, params):
     rec = rec.astype("float32")
     ns = rec.get_total_samples()
 
-    # un-whiten the data to be fed into the dartsort spike detector
-    # ignore OOB channels prior to computing a pseudoinverse of Wrot
-    Wrot = cp.asnumpy(ctx.intermediate.Wrot)
-    W = np.eye(probe.Nchan)
-    oob = probe.channel_labels != 3.
-    idx = np.ix_(oob, oob)
-    W[idx] = np.linalg.pinv(Wrot[idx])
-    W /= params.scaleproc
-
-    # transform the data to standard units via z-scoring, i.e. Z = (X-MU)/STDEV
-    # estimate the STDEV and MU vectors from chunks throughout recording
-    nchunk = 25
-    t0s = np.linspace(10, ns / params.fs - 10, nchunk)
-    stds = np.zeros((nchunk, probe.Nchan))
-    mus = np.zeros((nchunk, probe.Nchan))
-    for icc, t0 in enumerate(tqdm(t0s)):
-        s0, s1 = int(t0 * params.fs), int((t0 + 0.4) * params.fs)
-        # z-scoring is after unwhitening
-        chunk = W @ rec.get_traces(0, s0, s1).T
-        stds[icc, :] = np.std(chunk, axis=1)
-        mus[icc, :] = np.mean(chunk, axis=1)
-
-    std = np.median(stds, axis=0)
-    mu = np.median(mus, axis=0)
-
-    W[idx] /= std[oob]
-
-    rec = si.whiten(rec, W=W, M=mu, apply_mean=True)
+    if not params.skip_unwhiten_before_drift:
+        # un-whiten the data to be fed into the dartsort spike detector
+        # ignore OOB channels prior to computing a pseudoinverse of Wrot
+        Wrot = cp.asnumpy(ctx.intermediate.Wrot)
+        W = np.eye(probe.Nchan)
+        oob = probe.channel_labels != 3.
+        idx = np.ix_(oob, oob)
+        W[idx] = np.linalg.pinv(Wrot[idx])
+        W /= params.scaleproc
+    
+        # transform the data to standard units via z-scoring, i.e. Z = (X-MU)/STDEV
+        # estimate the STDEV and MU vectors from chunks throughout recording
+        nchunk = 25
+        t0s = np.linspace(10, ns / params.fs - 10, nchunk)
+        stds = np.zeros((nchunk, probe.Nchan))
+        mus = np.zeros((nchunk, probe.Nchan))
+        for icc, t0 in enumerate(tqdm(t0s)):
+            s0, s1 = int(t0 * params.fs), int((t0 + 0.4) * params.fs)
+            # z-scoring is after unwhitening
+            chunk = W @ rec.get_traces(0, s0, s1).T
+            stds[icc, :] = np.std(chunk, axis=1)
+            mus[icc, :] = np.mean(chunk, axis=1)
+    
+        std = np.median(stds, axis=0)
+        mu = np.median(mus, axis=0)
+    
+        W[idx] /= std[oob]
+    
+        rec = si.whiten(rec, W=W, M=mu, apply_mean=True)
 
     # now run DARTsort thresholding to get spike times, amps, positions
     channel_index = torch.tensor(dartsort.make_channel_index(geom, 100.0))

--- a/iblsorter/datashift2.py
+++ b/iblsorter/datashift2.py
@@ -580,15 +580,13 @@ def get_drift(spikes, probe, Nbatches, nblocks=5, genericSpkTh=10):
     return dshift, yblk
 
 
-def get_dredge_drift(spikes, params):
+def get_dredge_drift(spikes, params, motion_params):
     
     motion_est, _ = dredge_ap.register(
         spikes.amps,
         spikes.depths,
         spikes.times,
-        bin_s=params.NT / params.fs,
-        gaussian_smoothing_sigma_s=params.NT / params.fs,
-        mincorr=0.5,
+        **dict(motion_params)
     )
     
     dshift = -motion_est.displacement.T
@@ -632,7 +630,7 @@ def datashift2(ctx, qc_path=None):
         np.save(drift_path / 'spike_depths.npy', spikes.depths)
         np.save(drift_path / 'spike_amps.npy', spikes.amps)
 
-    motion_est, dshift, yblk = get_dredge_drift(spikes, params)
+    motion_est, dshift, yblk = get_dredge_drift(spikes, params, ctx.motion_params)
     if yblk is None and dshift.ndim == 1:
         yblk = np.atleast_1d(np.median(ctx.probe['y']))
         dshift = dshift[:, np.newaxis]

--- a/iblsorter/datashift2.py
+++ b/iblsorter/datashift2.py
@@ -442,7 +442,7 @@ def dartsort_detector(ctx, probe, params):
     rec = rec.astype("float32")
     ns = rec.get_total_samples()
 
-    if not params.skip_unwhiten_before_drift:
+    if params.unwhiten_before_drift:
         # un-whiten the data to be fed into the dartsort spike detector
         # ignore OOB channels prior to computing a pseudoinverse of Wrot
         Wrot = cp.asnumpy(ctx.intermediate.Wrot)

--- a/iblsorter/datashift2.py
+++ b/iblsorter/datashift2.py
@@ -649,7 +649,7 @@ def datashift2(ctx, qc_path=None):
         dat = ir.data_loader.load_batch(ibatch, rescale=False)
 
         # align via kriging interpolation
-        data_shifted = apply_drift_transform(dat, dshift[ibatch, :], yblk, probe, params.sig_datashift)
+        data_shifted = apply_drift_transform(dat, dshift[ibatch, :], yblk, probe, params.sig_datashift).astype(np.dtype(params.data_dtype))
 
         # write the aligned data back to the same file
         ir.data_loader.write_batch(ibatch, data_shifted)

--- a/iblsorter/ibl.py
+++ b/iblsorter/ibl.py
@@ -134,8 +134,8 @@ def ibl_pykilosort_params(bin_file):
 def ibl_dredge_params(pyks_params):
     # neuropixels 1/2 Dredge configs
     motion_params = MotionEstimationParams(
-        bin_s=pyks_params.NT / pyks_params.fs,
-        gaussian_smoothing_sigma_s=pyks_params.NT / pyks_params.fs,
+        bin_s=pyks_params["NT"] / pyks_params["fs"],
+        gaussian_smoothing_sigma_s=pyks_params["NT"] / pyks_params["fs"],
         mincorr=0.5
     )
 

--- a/iblsorter/ibl.py
+++ b/iblsorter/ibl.py
@@ -101,7 +101,7 @@ def run_spike_sorting_ibl(bin_file, scratch_dir=None, delete=True,
         _logger.info(f"Loaded probe geometry for NP{params['probe']['neuropixel_version']}")
 
         run(dat_path=bin_file, dir_path=scratch_dir, output_dir=ks_output_dir, 
-            stop_after=stop_after, motion_params=motion_params, **params)
+            stop_after=stop_after, motion_params=motion_params, **dict(params))
     except Exception as e:
         _logger.exception("Error in the main loop")
         raise e
@@ -129,13 +129,13 @@ def ibl_pykilosort_params(bin_file):
     params.channel_detection_method = 'raw_correlations'
     params.overlap_samples = 1024  # this needs to be a multiple of 1024
     params.probe = probe_geometry(bin_file)
-    return dict(params)
+    return params
 
 def ibl_dredge_params(pyks_params):
     # neuropixels 1/2 Dredge configs
     motion_params = MotionEstimationParams(
-        bin_s=pyks_params["NT"] / pyks_params["fs"],
-        gaussian_smoothing_sigma_s=pyks_params["NT"] / pyks_params["fs"],
+        bin_s=pyks_params.NT / pyks_params.fs,
+        gaussian_smoothing_sigma_s=pyks_params.NT / pyks_params.fs,
         mincorr=0.5
     )
 

--- a/iblsorter/ibl.py
+++ b/iblsorter/ibl.py
@@ -12,7 +12,7 @@ from ibllib.ephys import spikes
 from one.alf.files import get_session_path
 from one.remote import aws
 from iblsorter import add_default_handler, run, Bunch, __version__
-from iblsorter.params import KilosortParams
+from iblsorter.params import KilosortParams, MotionEstimationParams
 
 
 _logger = logging.getLogger(__name__)
@@ -63,7 +63,8 @@ def _sample2v(ap_file):
 
 
 def run_spike_sorting_ibl(bin_file, scratch_dir=None, delete=True,
-                          ks_output_dir=None, alf_path=None, log_level='INFO', stop_after=None, params=None):
+                          ks_output_dir=None, alf_path=None, log_level='INFO', stop_after=None, 
+                          params=None, motion_params=None):
     """
     This runs the spike sorting and outputs the raw pykilosort without ALF conversion
     :param bin_file: binary file full path
@@ -89,6 +90,13 @@ def run_spike_sorting_ibl(bin_file, scratch_dir=None, delete=True,
     # construct the probe geometry information
     if params is None:
         params = ibl_pykilosort_params(bin_file)
+    if motion_params is None:
+        # neuropixels 1/2 Dredge configs
+        motion_params = MotionEstimationParams(
+            bin_s=params.NT / params.fs,
+            gaussian_smoothing_sigma_s=params.NT / params.fs,
+            mincorr=0.5
+        )
     try:
         _logger.info(f"Starting Pykilosort version {__version__}")
         _logger.info(f"Scratch dir {scratch_dir}")

--- a/iblsorter/ibl.py
+++ b/iblsorter/ibl.py
@@ -91,12 +91,7 @@ def run_spike_sorting_ibl(bin_file, scratch_dir=None, delete=True,
     if params is None:
         params = ibl_pykilosort_params(bin_file)
     if motion_params is None:
-        # neuropixels 1/2 Dredge configs
-        motion_params = MotionEstimationParams(
-            bin_s=params.NT / params.fs,
-            gaussian_smoothing_sigma_s=params.NT / params.fs,
-            mincorr=0.5
-        )
+        motion_params = ibl_dredge_params(params)
     try:
         _logger.info(f"Starting Pykilosort version {__version__}")
         _logger.info(f"Scratch dir {scratch_dir}")
@@ -105,7 +100,8 @@ def run_spike_sorting_ibl(bin_file, scratch_dir=None, delete=True,
         _logger.info(f"Log file {log_file}")
         _logger.info(f"Loaded probe geometry for NP{params['probe']['neuropixel_version']}")
 
-        run(dat_path=bin_file, dir_path=scratch_dir, output_dir=ks_output_dir, stop_after=stop_after, **params)
+        run(dat_path=bin_file, dir_path=scratch_dir, output_dir=ks_output_dir, 
+            stop_after=stop_after, motion_params=motion_params, **params)
     except Exception as e:
         _logger.exception("Error in the main loop")
         raise e
@@ -135,6 +131,15 @@ def ibl_pykilosort_params(bin_file):
     params.probe = probe_geometry(bin_file)
     return dict(params)
 
+def ibl_dredge_params(pyks_params):
+    # neuropixels 1/2 Dredge configs
+    motion_params = MotionEstimationParams(
+        bin_s=pyks_params.NT / pyks_params.fs,
+        gaussian_smoothing_sigma_s=pyks_params.NT / pyks_params.fs,
+        mincorr=0.5
+    )
+
+    return motion_params
 
 def probe_geometry(bin_file):
     """

--- a/iblsorter/ibl.py
+++ b/iblsorter/ibl.py
@@ -98,7 +98,7 @@ def run_spike_sorting_ibl(bin_file, scratch_dir=None, delete=True,
         _logger.info(f"Output dir {ks_output_dir}")
         _logger.info(f"Data dir {bin_file.parent}")
         _logger.info(f"Log file {log_file}")
-        _logger.info(f"Loaded probe geometry for NP{params['probe']['neuropixel_version']}")
+        _logger.info(f"Loaded probe geometry for NP{params.probe.neuropixel_version}")
 
         run(dat_path=bin_file, dir_path=scratch_dir, output_dir=ks_output_dir, 
             stop_after=stop_after, motion_params=motion_params, **dict(params))

--- a/iblsorter/main.py
+++ b/iblsorter/main.py
@@ -28,6 +28,7 @@ def run(
     probe=None,
     stop_after=None,
     clear_context=False,
+    motion_params=None,
     **params,
 ):
     """Launch KiloSort 2.
@@ -45,6 +46,9 @@ def run(
     # Get params.
     params = KilosortParams(**params or {})
     assert params
+
+    # motion params
+    motion_params = motion_params or MotionEstimationParams()
 
     raw_data = RawDataLoader(dat_path, **params.ephys_reader_args)
 
@@ -74,6 +78,7 @@ def run(
 
     ctx = Context(ctx_path)
     ctx.params = params
+    ctx.motion_params = motion_params
     ctx.probe = probe
     ctx.raw_probe = copy_bunch(probe)
     ctx.raw_data = raw_data

--- a/iblsorter/main.py
+++ b/iblsorter/main.py
@@ -85,7 +85,7 @@ def run(
 
     if params.skip_preprocessing and not ctx.path("proc", ".dat").exists():
         shutil.copy(dat_path, ctx.path("proc", ".dat"))
-        ns2add = ceil(raw_data.n_samples / params.NT) * params.NT - raw_data.n_samples
+        ns2add = np.ceil(raw_data.n_samples / params.NT) * params.NT - raw_data.n_samples
         bytes2add = int(ns2add * params.n_channels * np.dtype(params.data_dtype).itemsize)
         print(bytes2add)
         with open(ctx.path("proc", ".dat"), "ab") as f:

--- a/iblsorter/params.py
+++ b/iblsorter/params.py
@@ -60,6 +60,48 @@ class DatashiftParams(BaseModel):
             )
         return v
 
+class MotionEstimationParams(BaseModel):
+    """
+    See https://github.com/evarol/dredge/blob/main/python/dredge/dredge_ap.py
+    """
+
+    bin_um: float = Field(1.0)
+    bin_s: float = Field(1.0)
+    
+    max_dt_s: float = Field(1000.)
+    mincorr: float = Field(0.1)
+
+    win_shape: str = Field("gaussian")
+    win_step_um: float = Field(400.)
+    win_scale_um: float = Field(450.)
+
+    # default depends on other parameters
+    max_disp_um: float | None = Field(None, description="", validate_default=True) 
+    @field_validator("max_disp_um")
+    def set_max_disp_um(cls, v, values):
+        return v or values.data["win_scale_um"] / 4.
+
+    # default depends on other parameters
+    win_margin_um: float | None = Field(None, description="", validate_default=True)  ## -win_scale_um / 2
+    def set_win_margin_um(cls, v, values):
+        return v or -values.data["win_scale_um"] / 2.
+
+    # weights parameters
+    do_window_weights: bool = Field(True)
+    weights_threshold_low: float = Field(0.2)
+    weights_threshold_high: float = Field(0.2)
+    mincorr_percentile: float | None = Field(None)
+    mincorr_percentile_nneighbs: float | None = Field(None)
+
+    # raster parameters
+    # amp_scale_fn=None,
+    # post_transform=np.log1p,
+    gaussian_smoothing_sigma_um: float = Field(1)
+    gaussian_smoothing_sigma_s: float = Field(1)
+    avg_in_bin: bool = Field(False)
+    count_masked_correlation: bool = Field(False)
+    count_bins: int = Field(401)
+    count_bin_min: int = Field(2)
 
 class KilosortParams(BaseModel):
     

--- a/iblsorter/params.py
+++ b/iblsorter/params.py
@@ -71,6 +71,9 @@ class KilosortParams(BaseModel):
     
     channel_detection_method: str = Field('kilosort', description = 'channel detection methods choices'
                                                                      'are "raw_correlations" or "kilosort"')
+
+    skip_preprocessing: bool = Field(False, description='skip IBL destriping if the bin file is already'
+                                                                                            'preprocessed')
     
     save_drift_spike_detections: bool = Field(False, description='save detected spikes in drift correction')
     

--- a/iblsorter/params.py
+++ b/iblsorter/params.py
@@ -81,6 +81,8 @@ class KilosortParams(BaseModel):
     
     perform_drift_registration: bool = Field(True, description='Estimate electrode drift and apply registration')
 
+    skip_unwhiten_before_drift: bool = Field(False, description='skip unwhitening operation prior to estimating drift')
+    
     normalisation: str = Field('whitening', description=
     'Normalisation strategy. Choices are: '
     '"whitening": uses the inverse of the covariance matrix,'

--- a/iblsorter/params.py
+++ b/iblsorter/params.py
@@ -83,6 +83,7 @@ class MotionEstimationParams(BaseModel):
 
     # default depends on other parameters
     win_margin_um: float | None = Field(None, description="", validate_default=True)  ## -win_scale_um / 2
+    @field_validator("win_margin_um")
     def set_win_margin_um(cls, v, values):
         return v or -values.data["win_scale_um"] / 2.
 

--- a/iblsorter/params.py
+++ b/iblsorter/params.py
@@ -1,5 +1,5 @@
-import typing as t
 from math import ceil
+from typing import List, Optional, Tuple, Literal, Union
 
 import numpy as np
 from pydantic import BaseModel, Field, field_validator, validator
@@ -12,10 +12,10 @@ from .utils import Bunch
 
 class Probe(BaseModel):
     NchanTOT: int
-    Nchan: t.Optional[int] = Field(
+    Nchan: Optional[int] = Field(
         None, description="Nchan < NchanTOT if some channels should not be used."
     )
-    shank: t.Optional[np.ndarray] = Field(
+    shank: Optional[np.ndarray] = Field(
         None, description="Channel shanks labels"
     )
     chanMap: np.ndarray  # TODO: add constraints
@@ -47,7 +47,7 @@ class DatashiftParams(BaseModel):
     nblocks: int = Field(
         5, description="blocks for registration. 1 does rigid registration."
     )
-    output_filename: t.Optional[str] = Field(
+    output_filename: Optional[str] = Field(
         None, description="optionally save registered data to a new binary file"
     )
     overwrite: bool = Field(True, description="overwrite proc file with shifted data")
@@ -104,186 +104,70 @@ class MotionEstimationParams(BaseModel):
     count_bins: int = Field(401)
     count_bin_min: int = Field(2)
 
+
+class ChannelDetectionParamsRawCorrelations(BaseModel):
+    psd_hf_threshold: float = Field(.02, description="Threshold power spectral density above which the PSD at 0.8 Nyquist is considered noisy (units: uV ** 2 / Hz ")
+    similarity_threshold: Optional[Tuple[float]] = Field((-.5, 1), description="similarity threshold for channel detection")
+
+
 class KilosortParams(BaseModel):
-    
-    low_memory: bool = Field(
-        False, description='low memory setting for running chronic recordings'
-    )
-    
-    seed: t.Optional[int] = Field(42, description="seed for deterministic output")
-    
-    channel_detection_method: str = Field('kilosort', description = 'channel detection methods choices'
-                                                                     'are "raw_correlations" or "kilosort"')
-
-    skip_preprocessing: bool = Field(False, description='skip IBL destriping if the bin file is already'
-                                                                                            'preprocessed')
-    
-    save_drift_spike_detections: bool = Field(False, description='save detected spikes in drift correction')
-    
-    save_drift_estimates: bool = Field(False, description='save estimated probe drift')
-    
-    perform_drift_registration: bool = Field(True, description='Estimate electrode drift and apply registration')
-
-    skip_unwhiten_before_drift: bool = Field(False, description='skip unwhitening operation prior to estimating drift')
-    
-    normalisation: str = Field('whitening', description=
-    'Normalisation strategy. Choices are: '
+    AUCsplit: float = Field(0.9,description="""splitting a cluster at the end requires at least this much isolation for each sub-cluster (max=1)""")
+    Nfilt: Optional[int] = None  # This should be a computed property once we add the probe to the config
+    Th: List[float] = Field([6, 3],description="""threshold on projections (like in Kilosort1, can be different for last pass like [10 4])""",)
+    ThPre: float = Field(8,description="threshold crossings for pre-clustering (in PCA projection space)",)
+    channel_detection_method: Literal['kilosort', 'raw_correlations'] = Field(
+        'kilosort', description='Method to detect faulty channels, kilosort uses firing rate, raw_correlations uses PSD and similarity')
+    channel_detection_parameters: Optional[ChannelDetectionParamsRawCorrelations] = Field(
+        ChannelDetectionParamsRawCorrelations(), description='parameters for raw correlation channel detection option')
+    data_dtype: str = Field('int16', description='data type of raw data')
+    datashift: Optional[DatashiftParams] = Field(None, description="parameters for 'datashift' drift correction. not required")
+    deterministic_mode: bool = Field(True, description="make output deterministic by sorting spikes before applying kernels")
+    fs: float = Field(30000.0, description="sample rate")
+    fshigh: float = Field(300.0, description="high pass filter frequency")
+    fslow: Optional[float] = Field(None, description="low pass filter frequency")
+    gain: int = 1
+    genericSpkTh: float = Field(8.0, description="threshold for crossings with generic templates")
+    lam: float = Field(10,description="""how important is the amplitude penalty (like in Kilosort1, 0 means not used,10 is average, 50 is a lot)""")
+    loc_range: List[int] = [5, 4]
+    long_range: List[int] = [30, 6]
+    low_memory: bool = Field(False, description='low memory setting for running chronic recordings')
+    minFR: float = Field(1.0 / 50,description="""minimum spike rate (Hz), if a cluster falls below this for too long it gets removed""",)
+    minfr_goodchannels: float = Field(0, description="minimum firing rate on a 'good' channel (0 to skip)")
+    momentum: List[float] = Field([20, 400],description="""number of samples to average over (annealed from first to second value)""")
+    normalisation: Literal['whitening', 'zscore', 'global zscore'] = Field('whitening', description='Normalisation strategy. Choices are: '
     '"whitening": uses the inverse of the covariance matrix,'
     '"zscore": uses individual channel normalisation,'
     '"global zscore" for median channel normalisation')
-
-    fs: float = Field(30000.0, description="sample rate")
-
-    data_dtype: str = Field('int16', description='data type of raw data')
-
-    n_channels: int = Field(385, description='number of channels in the data recording')
-
-    # [CR 2024-04-02]: add support for optional overlap at the beginning and end of each batch
-    overlap_samples: int = Field(0, description='number of overlap time samples to load at the beginning and end of each batch in the main template matching algorithm')
-
-    probe: t.Optional[Probe] = Field(None, description="recording probe metadata")
-
-    save_temp_files: bool = Field(
-        True, description="keep temporary files created while running"
-    )
-
-    fshigh: float = Field(300.0, description="high pass filter frequency")
-    fslow: t.Optional[float] = Field(None, description="low pass filter frequency")
-    minfr_goodchannels: float = Field(
-        0, description="minimum firing rate on a 'good' channel (0 to skip)"
-    )
-
-    genericSpkTh: float = Field(
-        8.0, description="threshold for crossings with generic templates"
-    )
-    nblocks: int = Field(
-        5,
-        description="number of blocks used to segment the probe when tracking drift, 0 == don't track, 1 == rigid, > 1 == non-rigid",
-    )
-    output_filename: t.Optional[str] = Field(
-        None, description="optionally save registered data to a new binary file"
-    )
-    overwrite: bool = Field(True, description="overwrite proc file with shifted data")
-
-    sig_datashift: float = Field(20.0, description="sigma for the Gaussian process smoothing")
-
-    stable_mode: bool = Field(True, description="make output more stable")
-    deterministic_mode: bool = Field(True, description="make output deterministic by sorting spikes before applying kernels")
-
-    @validator("deterministic_mode")
-    def validate_deterministic_mode(cls, v, values):
-        if values.get("stable_mode"):
-            return v
-        else:
-            if v:
-                warning = "stablemode must be enabled for deterministic results; " \
-                          "disabling deterministicmode"
-                raise UserWarning(warning)
-            return False
-
-    datashift: t.Optional[DatashiftParams] = Field(
-        None, description="parameters for 'datashift' drift correction. not required"
-    )
-
-    Th: t.List[float] = Field(
-        [6, 3],
-        description="""
-        threshold on projections (like in Kilosort1, can be different for last pass like [10 4])
-    """,
-    )
-    ThPre: float = Field(
-        8,
-        description="threshold crossings for pre-clustering (in PCA projection space)",
-    )
-
-    lam: float = Field(
-        10,
-        description="""
-        how important is the amplitude penalty (like in Kilosort1, 0 means not used,
-        10 is average, 50 is a lot)
-    """,
-    )
-
-    AUCsplit: float = Field(
-        0.9,
-        description="""
-        splitting a cluster at the end requires at least this much isolation for each sub-cluster (max=1)
-    """,
-    )
-
-    minFR: float = Field(
-        1.0 / 50,
-        description="""
-        minimum spike rate (Hz), if a cluster falls below this for too long it gets removed
-    """,
-    )
-
-    momentum: t.List[float] = Field(
-        [20, 400],
-        description="""
-        number of samples to average over (annealed from first to second value)
-    """,
-    )
-
-    sigmaMask: float = Field(
-        30,
-        description="""
-        spatial constant in um for computing residual variance of spike
-    """,
-    )
-
-    # danger, changing these settings can lead to fatal errors
-    # options for determining PCs
-    spkTh: float = Field(-6, description="spike threshold in standard deviations")
-    reorder: int = Field(
-        1, description="whether to reorder batches for drift correction."
-    )
-    nskip: int = Field(
-        5, description="how many batches to skip for determining spike PCs"
-    )
-    nSkipCov: int = Field(
-        25, description="compute whitening matrix from every nth batch"
-    )
-
-    # GPU = 1  # has to be 1, no CPU version yet, sorry
-    # Nfilt = 1024 # max number of clusters
-    nfilt_factor: int = Field(
-        4, description="max number of clusters per good channel (even temporary ones)"
-    )
-    ntbuff: int = Field(
-        64,
-        description="""
-    samples of symmetrical buffer for whitening and spike detection
-    
-    Must be multiple of 32 + ntbuff. This is the batch size (try decreasing if out of memory).
-    """,
-    )
-
-    whiteningRange: int = Field(
-        32, description="number of channels to use for whitening each channel"
-    )
-    nSkipCov: int = Field(
-        25, description="compute whitening matrix from every N-th batch"
-    )
-    scaleproc: int = Field(200, description="int16 scaling of whitened data")
     nPCs: int = Field(3, description="how many PCs to project the spikes into")
-
+    nSkipCov: int = Field(25, description="compute whitening matrix from every N-th batch")
+    n_channels: int = Field(385, description='number of channels in the data recording')
+    nblocks: int = Field(5, description="number of blocks used to segment the probe when tracking drift, 0 == don't track, 1 == rigid, > 1 == non-rigid")
+    nfilt_factor: int = Field(4, description="max number of clusters per good channel (even temporary ones)")
+    nskip: int = Field(5, description="how many batches to skip for determining spike PCs")
     nt0: int = 61
+    ntbuff: int = Field(64,description="""samples of symmetrical buffer for whitening and spike detection Must be multiple of 32 + ntbuff. This is the batch size (try decreasing if out of memory).""",)
     nup: int = 10
+    output_filename: Optional[str] = Field(None, description="optionally save registered data to a new binary file")
+    overlap_samples: int = Field(0, description='number of overlap time samples to load at the beginning and end of each batch in the main template matching algorithm')
+    overwrite: bool = Field(True, description="overwrite proc file with shifted data")
+    perform_drift_registration: bool = Field(True, description='Estimate electrode drift and apply registration')
+    probe: Optional[Probe] = Field(None, description="recording probe metadata")
+    read_only: bool = Field(False, description='Read only option for raw data') # TODO: Make this true by default
+    reorder: bool = Field(True, description="whether to reorder batches for drift correction.")
+    save_drift_estimates: bool = Field(False, description='save estimated probe drift')
+    save_drift_spike_detections: bool = Field(False, description='save detected spikes in drift correction')
+    save_temp_files: bool = Field(        True, description="keep temporary files created while running")
+    scaleproc: int = Field(200, description="int16 scaling of whitened data")
+    seed: Optional[int] = Field(42, description="seed for deterministic output")
     sig: int = 1
-    gain: int = 1
-
+    sig_datashift: float = Field(20.0, description="sigma for the Gaussian process smoothing")
+    sigmaMask: float = Field(30, description="""spatial constant in um for computing residual variance of spike""")
+    skip_preprocessing: bool = Field(False, description='skip IBL destriping if the bin file is already preprocessed')
+    spkTh: float = Field(-6, description="spike threshold in standard deviations")
+    stable_mode: bool = Field(True, description="make output more stable")
     templateScaling: float = 20.0
-
-    loc_range: t.List[int] = [5, 4]
-    long_range: t.List[int] = [30, 6]
-
-    Nfilt: t.Optional[
-        int
-    ] = None  # This should be a computed property once we add the probe to the config
-
-    # TODO: Make this true by default
-    read_only: bool = Field(False, description='Read only option for raw data')
+    unwhiten_before_drift: bool = Field(True, description='perform unwhitening operation prior to estimating drift')
+    whiteningRange: int = Field(32, description="number of channels to use for whitening each channel")
 
     # Computed properties
     @property

--- a/iblsorter/preprocess.py
+++ b/iblsorter/preprocess.py
@@ -280,7 +280,7 @@ def get_good_channels_raw_correlations(raw_data, params, probe, t0s=None, return
     for icc, t0 in enumerate(tqdm(t0s, desc="Auto-detection of noisy channels")):
         s0 = slice(int(t0 * params.fs), int((t0 + 0.4) * params.fs))
         raw = raw_data[s0][:, :probe.Nchan].T.astype(np.float32) * probe['sample2volt']
-        channel_labels[:, icc], _ = detect_bad_channels(raw, params.fs)
+        channel_labels[:, icc], _ = detect_bad_channels(raw, params.fs, **params.channel_detection_parameters.dict())
     channel_labels = scipy.stats.mode(channel_labels, axis=1)[0].squeeze()
     logger.info(f"Detected {np.sum(channel_labels == 1)} dead channels")
     logger.info(f"Detected {np.sum(channel_labels == 2)} noise channels")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 click
-cupy-cuda12x
 dartsort @ git+https://github.com/cwindolf/dartsort@main
 dredge @ git+https://github.com/evarol/dredge@main
 hdbscan

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pytest
+from iblsorter.params import MotionEstimationParams, KilosortParams
+from iblsorter.ibl import ibl_dredge_params
+
+def test_motion_params():
+    # test modify params
+    p = MotionEstimationParams(max_dt_s=1200.)
+    assert p.max_dt_s == 1200.
+    p = MotionEstimationParams()
+    p.max_dt_s = 1500.
+    assert p.max_dt_s == 1500.
+    # test validator default, should set to -win_scale_um/2
+    p = MotionEstimationParams(win_margin_um=None, win_scale_um=400.)
+    assert p.win_margin_um == -200.
+
+def test_kilosort_params():
+    # test modify params
+    p = KilosortParams(skip_preprocessing=True)
+    assert p.skip_preprocessing
+    p = KilosortParams()
+    p.skip_preprocessing = True
+    assert p.skip_preprocessing
+
+    # document property behavior
+    p = KilosortParams(n_channels=40, data_dtype="float64", fs=2500)
+    test_args = {"n_channels": 40, "dtype": "float64", "sample_rate": 2500}
+    assert p.ephys_reader_args == test_args
+
+    # can't set this directly
+    p = KilosortParams()
+    with pytest.raises(AttributeError):
+        p.ephys_reader_args = test_args
+
+    # setting it in constructor does not work either
+    p = KilosortParams(n_channels=40, data_dtype="float64", fs=2500, 
+                       ephys_reader_args={
+                           "n_channels": 384,
+                           "dtype": "float32",
+                           "sample_rate": 2500
+                       }
+                    )
+    assert p.ephys_reader_args == test_args
+
+def test_get_motion_params_from_kilosort_params():
+    k = KilosortParams()
+    p = ibl_dredge_params(k)
+    assert p.bin_s == p.gaussian_smoothing_sigma_s == k.NT / k.fs
+    assert p.mincorr == 0.5
+    
+    


### PR DESCRIPTION
- `params.skip_processing` for already preprocessed data
- Use `params.data_dtype` in more places to handle non-int16 raw data (e.g. float16)
- `params.skip_unwhiten_before_drift`, turn off inverse whitening transform before drift registration with `dredge`