### PR TITLE
Small stdevs in some channels crashes iblsorter

### DIFF
--- a/iblsorter/datashift2.py
+++ b/iblsorter/datashift2.py
@@ -466,7 +466,11 @@ def dartsort_detector(ctx, probe, params):
         std = np.median(stds, axis=0)
         mu = np.median(mus, axis=0)
     
+        valid = (probe.channel_labels == 0) & np.isfinite(std) & (std > 1e-6)
+        std[~valid] = 1
         W[idx] /= std[oob]
+        W[:, ~valid] = 0
+        mu[~valid] = 0
     
         rec = si.whiten(rec, W=W, M=mu, apply_mean=True)
 


### PR DESCRIPTION
I have a recording where some bad channels are not detected by get_good_channels().  I believe this is because some channels go out briefly during the session, due to a bad headstage, so ibldsp.voltage.detect_bad_channels() isn't called on the bad regions.  (To be clear this is on non-IBL npx 1.0 data.)

In `iblsorter.datashift2.dartsort_detector`, the pre-DARTsort transform estimates per-channel std and then divides `W` by it:

```python
std = np.median(stds, axis=0)
mu = np.median(mus, axis=0)
W[idx] /= std[oob]
rec = si.whiten(rec, W=W, M=mu, apply_mean=True)
```

On my data, this produced stds < 1e-6 for 60 channels (of which, 51 were still labelled "good" by get_bad_channels()).  The division eventually caused OOM (on a computer with 64gb ram + 200gb swap) due to lots of threshold crossings, with warnings like:

```text
>40000 spikes in chunk was larger than self.max_spikes_per_chunk=40000
```

This PR fixes the issue.  Not sure if you want to merge this to main because I'm assuming IBL QC throws away recordings like this, but it is very helpful if you are using iblsorter with precious data!
